### PR TITLE
1.21.11 Support by migrating to new registry-based gamerule API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.10
-yarn_mappings=1.21.10+build.1
-loader_version=0.17.3
-loom_version=1.11-SNAPSHOT
+minecraft_version=1.21.11
+yarn_mappings=1.21.11+build.3
+loader_version=0.18.1
+loom_version=1.13-SNAPSHOT
 
 # Mod Properties
-mod_version=1.5.0+1.21.9-1.21.10
+mod_version=1.6.0+1.21.11
 maven_group=net.enecske.mob_explosion_griefing
 archives_base_name=mob_explosion_griefing
 
 # Dependencies
-fabric_version=0.135.0+1.21.10
+fabric_version=0.139.4+1.21.11

--- a/src/main/java/net/enecske/mob_explosion_griefing/MobExplosionGriefingGamerule.java
+++ b/src/main/java/net/enecske/mob_explosion_griefing/MobExplosionGriefingGamerule.java
@@ -2,39 +2,54 @@ package net.enecske.mob_explosion_griefing;
 
 import net.fabricmc.api.ModInitializer;
 
-import net.fabricmc.fabric.api.gamerule.v1.GameRuleFactory;
-import net.fabricmc.fabric.api.gamerule.v1.GameRuleRegistry;
-import net.minecraft.world.GameRules;
+import net.fabricmc.fabric.api.gamerule.v1.GameRuleBuilder;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.rule.GameRule;
+import net.minecraft.world.rule.GameRuleCategory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MobExplosionGriefingGamerule implements ModInitializer {
-	public static final String MOD_ID = "mob_explosion_griefing";
+    public static final String MOD_ID = "mob_explosion_griefing";
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
-	public static final GameRules.Key<GameRules.BooleanRule> MOB_EXPLOSION_GRIEFING =
-			GameRuleRegistry.register("mobExplosionGriefing", GameRules.Category.MOBS, GameRuleFactory.createBooleanRule(true));
+    public static final GameRule<Boolean> MOB_EXPLOSION_GRIEFING = GameRuleBuilder
+        .forBoolean(true)
+        .category(GameRuleCategory.MOBS)
+        .buildAndRegister(Identifier.of(MOD_ID, "mob_explosion_griefing"));
 
-	public static final GameRules.Key<GameRules.BooleanRule> WITHER_GRIEFING =
-			GameRuleRegistry.register("witherGriefing", GameRules.Category.MOBS, GameRuleFactory.createBooleanRule(true));
+    public static final GameRule<Boolean> WITHER_GRIEFING = GameRuleBuilder
+        .forBoolean(true)
+        .category(GameRuleCategory.MOBS)
+        .buildAndRegister(Identifier.of(MOD_ID, "wither_griefing"));
 
-	public static final GameRules.Key<GameRules.BooleanRule> CREEPER_GRIEFING =
-			GameRuleRegistry.register("creeperGriefing", GameRules.Category.MOBS, GameRuleFactory.createBooleanRule(true));
+    public static final GameRule<Boolean> CREEPER_GRIEFING = GameRuleBuilder
+        .forBoolean(true)
+        .category(GameRuleCategory.MOBS)
+        .buildAndRegister(Identifier.of(MOD_ID, "creeper_griefing"));
 
-	public static final GameRules.Key<GameRules.BooleanRule> GHAST_GRIEFING =
-			GameRuleRegistry.register("ghastGriefing", GameRules.Category.MOBS, GameRuleFactory.createBooleanRule(true));
+    public static final GameRule<Boolean> GHAST_GRIEFING = GameRuleBuilder
+        .forBoolean(true)
+        .category(GameRuleCategory.MOBS)
+        .buildAndRegister(Identifier.of(MOD_ID, "ghast_griefing"));
 
-	public static final GameRules.Key<GameRules.BooleanRule> ENDERMAN_GRIEFING =
-			GameRuleRegistry.register("endermanGriefing", GameRules.Category.MOBS, GameRuleFactory.createBooleanRule(true));
+    public static final GameRule<Boolean> ENDERMAN_GRIEFING = GameRuleBuilder
+        .forBoolean(true)
+        .category(GameRuleCategory.MOBS)
+        .buildAndRegister(Identifier.of(MOD_ID, "enderman_griefing"));
 
-	public static final GameRules.Key<GameRules.BooleanRule> DOOR_BREAKING_GRIEFING =
-			GameRuleRegistry.register("doorBreakingGriefing", GameRules.Category.MOBS, GameRuleFactory.createBooleanRule(true));
+    public static final GameRule<Boolean> DOOR_BREAKING_GRIEFING = GameRuleBuilder
+        .forBoolean(true)
+        .category(GameRuleCategory.MOBS)
+        .buildAndRegister(Identifier.of(MOD_ID, "door_breaking_griefing"));
 
-	public static final GameRules.Key<GameRules.BooleanRule> STEP_AND_DESTROY_GOAL =
-			GameRuleRegistry.register("stepAndDestroyGoal", GameRules.Category.MOBS, GameRuleFactory.createBooleanRule(true));
+    public static final GameRule<Boolean> STEP_AND_DESTROY_GOAL = GameRuleBuilder
+        .forBoolean(true)
+        .category(GameRuleCategory.MOBS)
+        .buildAndRegister(Identifier.of(MOD_ID, "step_and_destroy_goal"));
 
-	@Override
-	public void onInitialize() {
-		LOGGER.info("MobExplosionGriefingGamerule is loaded!");
-	}
+    @Override
+    public void onInitialize() {
+        LOGGER.info("MobExplosionGriefingGamerule is loaded!");
+    }
 }

--- a/src/main/java/net/enecske/mob_explosion_griefing/mixin/BreakDoorGoalMixin.java
+++ b/src/main/java/net/enecske/mob_explosion_griefing/mixin/BreakDoorGoalMixin.java
@@ -2,17 +2,18 @@ package net.enecske.mob_explosion_griefing.mixin;
 
 import net.enecske.mob_explosion_griefing.MobExplosionGriefingGamerule;
 import net.minecraft.entity.ai.goal.BreakDoorGoal;
-import net.minecraft.world.GameRules;
+import net.minecraft.world.rule.GameRule;
+import net.minecraft.world.rule.GameRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(BreakDoorGoal.class)
 public class BreakDoorGoalMixin {
-    @Redirect(method = "canStart", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getBoolean(Lnet/minecraft/world/GameRules$Key;)Z"))
-    public boolean redirectGameruleQuery(GameRules instance, GameRules.Key<GameRules.BooleanRule> rule) {
+    @Redirect(method = "canStart", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/rule/GameRules;getValue(Lnet/minecraft/world/rule/GameRule;)Ljava/lang/Object;"))
+    public Object redirectGameruleQuery(GameRules instance, GameRule<Boolean> rule) {
         if (rule == GameRules.DO_MOB_GRIEFING)
-            return instance.getBoolean(GameRules.DO_MOB_GRIEFING) && instance.getBoolean(MobExplosionGriefingGamerule.DOOR_BREAKING_GRIEFING);
-        else return instance.getBoolean(rule);
+            return instance.getValue(GameRules.DO_MOB_GRIEFING) && instance.getValue(MobExplosionGriefingGamerule.DOOR_BREAKING_GRIEFING);
+        else return instance.getValue(rule);
     }
 }

--- a/src/main/java/net/enecske/mob_explosion_griefing/mixin/FireballEntityMixin.java
+++ b/src/main/java/net/enecske/mob_explosion_griefing/mixin/FireballEntityMixin.java
@@ -7,8 +7,9 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.mob.GhastEntity;
 import net.minecraft.entity.projectile.FireballEntity;
 import net.minecraft.entity.projectile.ProjectileEntity;
-import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
+import net.minecraft.world.rule.GameRule;
+import net.minecraft.world.rule.GameRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -18,8 +19,8 @@ public abstract class FireballEntityMixin extends ProjectileEntity {
         super(entityType, world);
     }
 
-    @WrapOperation(method = "onCollision", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getBoolean(Lnet/minecraft/world/GameRules$Key;)Z"))
-    private boolean redirectMobGriefing(GameRules instance, GameRules.Key<GameRules.BooleanRule> rule, Operation<Boolean> original) {
+    @WrapOperation(method = "onCollision", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/rule/GameRules;getValue(Lnet/minecraft/world/rule/GameRule;)Ljava/lang/Object;"))
+    private Object redirectMobGriefing(GameRules instance, GameRule<Boolean> rule, Operation<Boolean> original) {
         if (rule == GameRules.DO_MOB_GRIEFING && getOwner() instanceof GhastEntity)
             return original.call(instance, MobExplosionGriefingGamerule.GHAST_GRIEFING) && original.call(instance, GameRules.DO_MOB_GRIEFING);
         return original.call(instance, rule);

--- a/src/main/java/net/enecske/mob_explosion_griefing/mixin/ProjectileEntityMixin.java
+++ b/src/main/java/net/enecske/mob_explosion_griefing/mixin/ProjectileEntityMixin.java
@@ -4,14 +4,15 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.enecske.mob_explosion_griefing.MobExplosionGriefingGamerule;
 import net.minecraft.entity.projectile.ProjectileEntity;
-import net.minecraft.world.GameRules;
+import net.minecraft.world.rule.GameRule;
+import net.minecraft.world.rule.GameRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(ProjectileEntity.class)
 public class ProjectileEntityMixin {
-    @WrapOperation(method = "canModifyAt", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getBoolean(Lnet/minecraft/world/GameRules$Key;)Z"))
-    private boolean redirectMobGriefing(GameRules instance, GameRules.Key<GameRules.BooleanRule> rule, Operation<Boolean> original) {
+    @WrapOperation(method = "canModifyAt", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/rule/GameRules;getValue(Lnet/minecraft/world/rule/GameRule;)Ljava/lang/Object;"))
+    private Object redirectMobGriefing(GameRules instance, GameRule<Boolean> rule, Operation<Boolean> original) {
         if (rule == GameRules.DO_MOB_GRIEFING)
             return original.call(instance, MobExplosionGriefingGamerule.MOB_EXPLOSION_GRIEFING) && original.call(instance, GameRules.DO_MOB_GRIEFING);
         return original.call(instance, rule);

--- a/src/main/java/net/enecske/mob_explosion_griefing/mixin/ServerWorldMixin.java
+++ b/src/main/java/net/enecske/mob_explosion_griefing/mixin/ServerWorldMixin.java
@@ -10,8 +10,9 @@ import net.minecraft.entity.mob.GhastEntity;
 import net.minecraft.entity.projectile.FireballEntity;
 import net.minecraft.entity.projectile.WitherSkullEntity;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.world.GameRules;
 import net.minecraft.world.explosion.Explosion;
+import net.minecraft.world.rule.GameRule;
+import net.minecraft.world.rule.GameRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -23,43 +24,43 @@ public abstract class ServerWorldMixin {
     public abstract GameRules getGameRules();
 
     @Shadow
-    protected abstract Explosion.DestructionType getDestructionType(GameRules.Key<GameRules.BooleanRule> decayRule);
+    protected abstract Explosion.DestructionType getDestructionType(GameRule<Boolean> decayRule);
 
     @ModifyExpressionValue(
             method = "createExplosion",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/server/world/ServerWorld;getDestructionType(Lnet/minecraft/world/GameRules$Key;)Lnet/minecraft/world/explosion/Explosion$DestructionType;"
+                    target = "Lnet/minecraft/server/world/ServerWorld;getDestructionType(Lnet/minecraft/world/rule/GameRule;)Lnet/minecraft/world/explosion/Explosion$DestructionType;"
             ),
             slice = @Slice(
                     from = @At(
                             value = "FIELD",
-                            target = "Lnet/minecraft/world/GameRules;MOB_EXPLOSION_DROP_DECAY:Lnet/minecraft/world/GameRules$Key;"
+                            target = "Lnet/minecraft/world/rule/GameRules;MOB_EXPLOSION_DROP_DECAY:Lnet/minecraft/world/rule/GameRule;"
                     )
             )
     )
     private Explosion.DestructionType modifyMobExplosionGriefing(Explosion.DestructionType original, @Local(argsOnly = true) Entity entity) {
-        if (!this.getGameRules().getBoolean(GameRules.DO_MOB_GRIEFING)) return Explosion.DestructionType.KEEP;
+        if (!this.getGameRules().getValue(GameRules.DO_MOB_GRIEFING)) return Explosion.DestructionType.KEEP;
 
         return switch (entity) {
             case WitherSkullEntity ignored -> {
-                if (this.getGameRules().getBoolean(MobExplosionGriefingGamerule.WITHER_GRIEFING))
+                if (this.getGameRules().getValue(MobExplosionGriefingGamerule.WITHER_GRIEFING))
                     yield this.getDestructionType(GameRules.MOB_EXPLOSION_DROP_DECAY);
                 yield Explosion.DestructionType.KEEP;
             }
             case WitherEntity ignored -> {
-                if (this.getGameRules().getBoolean(MobExplosionGriefingGamerule.WITHER_GRIEFING))
+                if (this.getGameRules().getValue(MobExplosionGriefingGamerule.WITHER_GRIEFING))
                     yield this.getDestructionType(GameRules.MOB_EXPLOSION_DROP_DECAY);
                 yield Explosion.DestructionType.KEEP;
             }
             case CreeperEntity ignored -> {
-                if (this.getGameRules().getBoolean(MobExplosionGriefingGamerule.CREEPER_GRIEFING) && this.getGameRules().getBoolean(MobExplosionGriefingGamerule.MOB_EXPLOSION_GRIEFING))
+                if (this.getGameRules().getValue(MobExplosionGriefingGamerule.CREEPER_GRIEFING) && this.getGameRules().getValue(MobExplosionGriefingGamerule.MOB_EXPLOSION_GRIEFING))
                     yield this.getDestructionType(GameRules.MOB_EXPLOSION_DROP_DECAY);
                 yield Explosion.DestructionType.KEEP;
             }
             case FireballEntity fireball -> {
                 if (fireball.getOwner() instanceof GhastEntity) {
-                    if (this.getGameRules().getBoolean(MobExplosionGriefingGamerule.GHAST_GRIEFING) && this.getGameRules().getBoolean(MobExplosionGriefingGamerule.MOB_EXPLOSION_GRIEFING))
+                    if (this.getGameRules().getValue(MobExplosionGriefingGamerule.GHAST_GRIEFING) && this.getGameRules().getValue(MobExplosionGriefingGamerule.MOB_EXPLOSION_GRIEFING))
                         yield this.getDestructionType(GameRules.MOB_EXPLOSION_DROP_DECAY);
                     yield Explosion.DestructionType.KEEP;
                 }
@@ -67,6 +68,5 @@ public abstract class ServerWorldMixin {
             }
             default -> original;
         };
-
     }
 }

--- a/src/main/java/net/enecske/mob_explosion_griefing/mixin/StepAndDestroyBlockGoalMixin.java
+++ b/src/main/java/net/enecske/mob_explosion_griefing/mixin/StepAndDestroyBlockGoalMixin.java
@@ -2,17 +2,18 @@ package net.enecske.mob_explosion_griefing.mixin;
 
 import net.enecske.mob_explosion_griefing.MobExplosionGriefingGamerule;
 import net.minecraft.entity.ai.goal.StepAndDestroyBlockGoal;
-import net.minecraft.world.GameRules;
+import net.minecraft.world.rule.GameRule;
+import net.minecraft.world.rule.GameRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(StepAndDestroyBlockGoal.class)
 public class StepAndDestroyBlockGoalMixin {
-    @Redirect(method = "canStart", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getBoolean(Lnet/minecraft/world/GameRules$Key;)Z"))
-    public boolean redirectGameruleQuery(GameRules instance, GameRules.Key<GameRules.BooleanRule> rule) {
+    @Redirect(method = "canStart", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/rule/GameRules;getValue(Lnet/minecraft/world/rule/GameRule;)Ljava/lang/Object;"))
+    public Object redirectGameruleQuery(GameRules instance, GameRule<Boolean> rule) {
         if (rule == GameRules.DO_MOB_GRIEFING)
-            return instance.getBoolean(GameRules.DO_MOB_GRIEFING) && instance.getBoolean(MobExplosionGriefingGamerule.STEP_AND_DESTROY_GOAL);
-        else return instance.getBoolean(rule);
+            return instance.getValue(GameRules.DO_MOB_GRIEFING) && instance.getValue(MobExplosionGriefingGamerule.STEP_AND_DESTROY_GOAL);
+        else return instance.getValue(rule);
     }
 }

--- a/src/main/java/net/enecske/mob_explosion_griefing/mixin/WitherEntityMixin.java
+++ b/src/main/java/net/enecske/mob_explosion_griefing/mixin/WitherEntityMixin.java
@@ -4,14 +4,15 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.enecske.mob_explosion_griefing.MobExplosionGriefingGamerule;
 import net.minecraft.entity.boss.WitherEntity;
-import net.minecraft.world.GameRules;
+import net.minecraft.world.rule.GameRule;
+import net.minecraft.world.rule.GameRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(WitherEntity.class)
 public class WitherEntityMixin {
-    @WrapOperation(method = "mobTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getBoolean(Lnet/minecraft/world/GameRules$Key;)Z"))
-    private boolean redirectBlockBreakingGriefing(GameRules instance, GameRules.Key<GameRules.BooleanRule> rule, Operation<Boolean> original) {
+    @WrapOperation(method = "mobTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/rule/GameRules;getValue(Lnet/minecraft/world/rule/GameRule;)Ljava/lang/Object;"))
+    private Object redirectBlockBreakingGriefing(GameRules instance, GameRule<Boolean> rule, Operation<Boolean> original) {
         if (rule == GameRules.DO_MOB_GRIEFING)
             return original.call(instance, MobExplosionGriefingGamerule.WITHER_GRIEFING) && original.call(instance, GameRules.DO_MOB_GRIEFING);
         return original.call(instance, rule);

--- a/src/main/java/net/enecske/mob_explosion_griefing/mixin/enderman_entity/PickUpBlockGoalMixin.java
+++ b/src/main/java/net/enecske/mob_explosion_griefing/mixin/enderman_entity/PickUpBlockGoalMixin.java
@@ -4,15 +4,15 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.enecske.mob_explosion_griefing.MobExplosionGriefingGamerule;
 import net.minecraft.entity.ai.goal.Goal;
-import net.minecraft.world.GameRules;
+import net.minecraft.world.rule.GameRule;
+import net.minecraft.world.rule.GameRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(targets = "net.minecraft.entity.mob.EndermanEntity$PickUpBlockGoal")
 public abstract class PickUpBlockGoalMixin extends Goal {
-    @WrapOperation(method = "canStart", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getBoolean(Lnet/minecraft/world/GameRules$Key;)Z"))
-    private boolean modifyCanStart(GameRules instance, GameRules.Key<GameRules.BooleanRule> rule, Operation<Boolean> original) {
+    @WrapOperation(method = "canStart", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/rule/GameRules;getValue(Lnet/minecraft/world/rule/GameRule;)Ljava/lang/Object;"))
+    private Object modifyCanStart(GameRules instance, GameRule<Boolean> rule, Operation<Boolean> original) {
         return original.call(instance, MobExplosionGriefingGamerule.ENDERMAN_GRIEFING) && original.call(instance, GameRules.DO_MOB_GRIEFING);
     }
-
 }

--- a/src/main/java/net/enecske/mob_explosion_griefing/mixin/enderman_entity/PlaceBlockGoalMixin.java
+++ b/src/main/java/net/enecske/mob_explosion_griefing/mixin/enderman_entity/PlaceBlockGoalMixin.java
@@ -4,14 +4,15 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.enecske.mob_explosion_griefing.MobExplosionGriefingGamerule;
 import net.minecraft.entity.ai.goal.Goal;
-import net.minecraft.world.GameRules;
+import net.minecraft.world.rule.GameRule;
+import net.minecraft.world.rule.GameRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(targets = "net.minecraft.entity.mob.EndermanEntity$PlaceBlockGoal")
 public abstract class PlaceBlockGoalMixin extends Goal {
-    @WrapOperation(method = "canStart", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getBoolean(Lnet/minecraft/world/GameRules$Key;)Z"))
-    private boolean modifyCanStart(GameRules instance, GameRules.Key<GameRules.BooleanRule> rule, Operation<Boolean> original) {
+    @WrapOperation(method = "canStart", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/rule/GameRules;getValue(Lnet/minecraft/world/rule/GameRule;)Ljava/lang/Object;"))
+    private Object modifyCanStart(GameRules instance, GameRule<Boolean> rule, Operation<Boolean> original) {
         return original.call(instance, MobExplosionGriefingGamerule.ENDERMAN_GRIEFING) && original.call(instance, GameRules.DO_MOB_GRIEFING);
     }
 }

--- a/src/main/resources/assets/mob_explosion_griefing/lang/en_us.json
+++ b/src/main/resources/assets/mob_explosion_griefing/lang/en_us.json
@@ -1,9 +1,9 @@
 {
-  "gamerule.mobExplosionGriefing": "Allow destructive mob explosions",
-  "gamerule.witherGriefing": "Allow destructive Wither actions",
-  "gamerule.endermanGriefing": "Allow Endermen to pick up blocks",
-  "gamerule.creeperGriefing": "Allow Creeper explosions to destroy blocks",
-  "gamerule.ghastGriefing": "Allow Ghast Fireballs to destroy blocks and light fires",
-  "gamerule.doorBreakingGriefing": "Allow mobs to break doors",
-  "gamerule.stepAndDestroyGoal": "Allow certain mobs to pathfind to blocks (e.g. Turtle Eggs) in order to destroy them"
+  "gamerule.mob_explosion_griefing.mob_explosion_griefing": "Allow destructive mob explosions",
+  "gamerule.mob_explosion_griefing.wither_griefing": "Allow destructive Wither actions",
+  "gamerule.mob_explosion_griefing.enderman_griefing": "Allow Endermen to pick up blocks",
+  "gamerule.mob_explosion_griefing.creeper_griefing": "Allow Creeper explosions to destroy blocks",
+  "gamerule.mob_explosion_griefing.ghast_griefing": "Allow Ghast Fireballs to destroy blocks and light fires",
+  "gamerule.mob_explosion_griefing.door_breaking_griefing": "Allow mobs to break doors",
+  "gamerule.mob_explosion_griefing.step_and_destroy_goal": "Allow certain mobs to pathfind to blocks (e.g. Turtle Eggs) in order to destroy them"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,8 +26,8 @@
 		"mob_explosion_griefing.mixins.json"
 	],
 	"depends": {
-		"fabricloader": ">=0.16.0",
-		"minecraft": ">=1.21.9 <=1.21.10",
+		"fabricloader": ">=0.18.1",
+		"minecraft": ">=1.21.11",
 		"java": ">=21",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
<img width="1902" height="567" alt="image" src="https://github.com/user-attachments/assets/9e0b2157-f742-4a62-98da-6bbf3b159199" />

Minecraft 1.21.11 moved from hardcoded gamerules to registry-based gamerules, so I did that to support 1.21.11, including complying to the new snake case gamerule convention.

The thing I haven't explored here is migrating the gamerules from updating to 1.21.11, so probably you need to set the gamerules again after updating a world to 1.21.11, unless you/others can help me with that which would be greatly appreciated!